### PR TITLE
release 3.0.0

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,39 @@
+# EditorConfig. Frontend. Default. Namics.
+# @see: http://EditorConfig.org
+# install a plugin to your editor: http://editorconfig.org/#download
+# mark: not all plugins supports the same EditorConfig properties
+
+# This is the top-most .editorconfig file (do not search in parent directories)
+root = true
+
+### All files
+[*]
+# Force charset utf-8
+charset = utf-8
+# Force Unix-style newlines with a newline ending every file & trim trailing whitespace
+end_of_line = lf
+# Indentation
+indent_style = tab
+indent_size = 4
+
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+### Frontend files
+[*.{css,scss,less,js,json,ts,sass,php,html,hbs,mustache,phtml,html.twig}]
+
+### Markdown
+[*.md]
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = false
+
+### YAML
+[*.yml]
+indent_style = space
+indent_size = 2
+
+### Specific files
+[{package,bower}.json]
+indent_style = space
+indent_size = 2

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,28 +1,3 @@
 {
-  "extends": "eslint:recommended",
-  "env": {
-    "node": true
-  },
-  "rules": {
-    "comma-dangle": [2, "always-multiline"],
-    "curly": 0,
-    "radix": 2,
-    "wrap-iife": 2,
-    "brace-style": 0,
-    "comma-style": 2,
-    "consistent-this": 0,
-    "indent": [2, 2, {
-      "SwitchCase": 1
-    }],
-    "no-console": 0,
-    "no-lonely-if": 2,
-    "no-nested-ternary": 2,
-    "no-use-before-define": [2, "nofunc"],
-    "quotes": [2, "single"],
-    "space-before-function-paren": [2, "never"],
-    "space-after-keywords": [2, "always"],
-    "space-before-blocks": [2, "always"],
-    "space-in-parens": [2, "never"],
-    "space-unary-ops": 2
-  }
+  "extends": "@namics/eslint-config/configurations/es6-node.js"
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - "0.12"
   - "4"
   - "5"
   - "6"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 3.0.0
+
+- drop node 0.12 support
+- use namics code style
+- forbid placing modifiers in front of elements
+- allow to use multiple elements e.g. [prefix]-[block]__[element]__[element]
+
 ## 2.1.0
 
 - allow less mixins with props

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Stylelint BEM Namics 
+# Stylelint BEM Namics
 [![Build Status](https://travis-ci.org/namics/stylelint-bem-namics.svg?branch=master)](https://travis-ci.org/namics/stylelint-bem-namics) [![npm version](https://badge.fury.io/js/%40namics%2Fstylelint-bem.svg)](https://badge.fury.io/js/%40namics%2Fstylelint-bem) [![Dependency Status](https://david-dm.org/namics/stylelint-bem-namics.svg)](https://david-dm.org/namics/stylelint-bem-namics)
 
 Verifies that the given css follows the namics BEM rules.
@@ -62,6 +62,13 @@ npm install @namics/stylelint-bem --save-dev
 .l-[block-name]__[element-name] {}
 .g-[block-name]__[element-name] {}
 .h-[block-name]__[element-name] {}
+
+.a-[block-name]__[element-name]__[element-name] {}
+.m-[block-name]__[element-name]__[element-name] {}
+.o-[block-name]__[element-name]__[element-name] {}
+.l-[block-name]__[element-name]__[element-name] {}
+.g-[block-name]__[element-name]__[element-name] {}
+.h-[block-name]__[element-name]__[element-name] {}
 
 .state-a-[block-name]--[state-name] {}
 .state-m-[block-name]--[state-name] {}

--- a/index.js
+++ b/index.js
@@ -1,140 +1,209 @@
+/* eslint complexity:off */
+'use strict';
 // @see https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/plugins.md
-var stylelint = require('stylelint');
-var resolvedNestedSelector = require('postcss-resolve-nested-selector');
-var extractCssClasses = require('css-selector-classes');
+const stylelint = require('stylelint');
+const resolvedNestedSelector = require('postcss-resolve-nested-selector');
+const extractCssClasses = require('css-selector-classes');
 
-var ruleName = 'plugin/stylelint-bem-namics';
-var messages = stylelint.utils.ruleMessages(ruleName, {
-  expected: function expected(selector, expectedSelector) {
-    return 'Expected class name \"' + selector + '\" to ' + expectedSelector + '.';
-  },
+const ruleName = 'plugin/stylelint-bem-namics';
+const messages = stylelint.utils.ruleMessages(ruleName, {
+	expected: function expected(selector, expectedSelector) {
+		return `Expected class name "${selector}\" to ${expectedSelector}.`;
+	}
 });
 
-module.exports = stylelint.createPlugin(ruleName, function(options) {
-  options = options || '';
+module.exports = stylelint.createPlugin(ruleName, (options) => {
+	options = options || '';
 
-  var validComponents = [
-    'a',
-    'm',
-    'o',
-    'l',
-    'g',
-    'h',
-  ];
-  var validHelpers = [
-    'state',
-  ];
+	const validComponents = [
+		'a',
+		'm',
+		'o',
+		'l',
+		'g',
+		'h'
+	];
 
-  var validPrefixes = []
-    .concat(validComponents)
-    .concat(validHelpers);
+	const validHelpers = [
+		'state'
+	];
 
-  function getClassNameErrors(className, namespace) {
-    var patternStart = '';
-    var patternEnd = '';
+	const validPrefixes = []
+		.concat(validComponents)
+		.concat(validHelpers);
 
-    if (/[A-Z]/.test(className)) {
-      return 'contain no uppercase letters';
-    }
-    if (namespace) {
-      if (className.indexOf(namespace) !== 0) {
-        return 'use the namespace "' + namespace + '"';
-      }
-      className = className.substr(namespace.length);
-      patternStart += namespace;
-    }
+	/**
+	 * Extracts the namespace, helper and prefix from the given className
+	 * 'ux-state-a-button'
+	 * @param {string} fullClassName the class name
+	 * @param {string} namespace (optional) namespace
+	 * @returns {Object} namespace, helper, component, name
+	 *
+	 */
+	function parseClassName(fullClassName, namespace) {
+		const result = {};
+		let className = fullClassName;
+		// Extract the namespace
+		if (namespace) {
+			if (className.indexOf(namespace) !== 0) {
+				return result;
+			}
+			result.namespace = namespace;
+			className = className.substr(namespace.length);
+		}
+		// Handle className with helper prefixes
+		const helperPrefix = className.split('-')[0];
+		if (validHelpers.indexOf(helperPrefix) !== -1) {
+			result.helper = helperPrefix;
+			className = className.substr(helperPrefix.length + 1);
+		}
+		// Handle classNames with prefixes
+		const componentPrefix = className.split('-')[0];
+		if (validComponents.indexOf(componentPrefix) !== -1) {
+			result.component = componentPrefix;
+			className = className.substr(componentPrefix.length + 1);
+		}
+		result.name = className;
+		return result;
+	}
 
-    var prefix = className.split('-')[0];
-    var helper = '';
-    if (className.indexOf('-') === -1 || validPrefixes.indexOf(prefix) === -1) {
-      return 'start with a valid prefix: "' + namespace + validPrefixes.join('-", "' + namespace) + '-"'
-    }
-    if (validHelpers.indexOf(prefix) !== -1) {
-      helper = prefix;
-      prefix = className.split('-')[1];
-      patternStart += helper + '-';
-      patternEnd += '--[' + helper + ']';
-      className = className.substr(helper.length + 1 + prefix.length + 1);
-      if (validComponents.indexOf(prefix) === -1) {
-        return 'use ' + patternStart + '[prefix]-[block]' + patternEnd + ' syntax. Valid ' + namespace + helper + ' prefixes: "' + namespace +
-          validComponents.map(function(component) {
-            return helper + '-' + component;
-          }).join('-", "' + namespace) + '-"';
-      }
-    }
-    else {
-      className = className.substr(prefix.length + 1);
-    }
+	/**
+	 * Helper for error messages to tell the correct syntax
+	 *
+	 * @param {string} className the class name
+	 * @param {string} namespace (optional) namespace
+	 * @returns {string} valid syntax
+	 */
+	function getValidSyntax(className, namespace) {
+		const parsedClassName = parseClassName(className, namespace);
+		let validSyntax = namespace;
+		if (parsedClassName.helper) {
+			validSyntax += `${parsedClassName.helper}-`;
+		}
+		if (parsedClassName.component) {
+			validSyntax += `${parsedClassName.component}-`;
+		} else {
+			validSyntax += '[prefix]-';
+		}
+		validSyntax += '[block]';
+		if (className.indexOf('__') !== -1) {
+			validSyntax += '__[element]';
+		}
+		if (parsedClassName.helper === 'state') {
+			validSyntax += '--[state]';
+		} else if (className.indexOf('--') !== -1) {
+			validSyntax += '--[modifier]';
+		}
+		return validSyntax;
+	}
 
-    if (!/^[a-z]/.test(className)) {
-      return 'use ' + patternStart + '[prefix]-[block]' + patternEnd + ' syntax';
-    }
-    if (/__(_|.*__)/.test(className)) {
-      return 'use only one "__" element separator';
-    }
-    if (/--(-|.*--)/.test(className)) {
-      return 'use only one "--" modifier separator';
-    }
-    if (/(^|[^_])_([^_]|$)/.test(className)) {
-      return 'use "_" only as element separator'
-    }
-    if (helper === 'state' && className.indexOf('--') === -1) {
-      return 'use ' + patternStart + '[prefix]-[block]' + patternEnd + ' syntax';
-    }
-  }
+	/**
+	 * Validates the given className and returns the error if it's not valid
+	 * @param {string} className - the name of the class e.g. 'a-button'
+	 * @param {string} namespace - the namespace (optional)
+	 * @returns {string} error message
+	 */
+	function getClassNameErrors(className, namespace) {
 
-  return function(root, result) {
-    var validOptions = stylelint.utils.validateOptions({
-      ruleName: ruleName,
-      result: result,
-      actual: options,
-    });
+		if (/[A-Z]/.test(className)) {
+			return 'contain no uppercase letters';
+		}
 
-    if (!validOptions) {
-      return;
-    }
+		const parsedClassName = parseClassName(className, namespace);
+		if (namespace && namespace !== parsedClassName.namespace) {
+			return `use the namespace "${namespace}"`;
+		}
 
-    var namespace = options.namespace || '';
-    var classNameErrorCache = {};
-    root.walkRules(function(rule) {
-      // Skip keyframes
-      if (rule.parent.name === 'keyframes') {
-        return;
-      }
-      rule.selectors.forEach(function(selector) {
-        if (selector.indexOf('(') !== -1 && (selector.indexOf(':') === -1 || selector.indexOf('@') !== -1)) {
-          // Skip less mixins
-          return;
-        }
-        resolvedNestedSelector(selector, rule).forEach(function(resolvedSelector) {
-          var classNames = [];
-          try {
-            classNames = extractCssClasses(resolvedSelector);
-          } catch (e) {
-            stylelint.utils.report({
-              ruleName: ruleName,
-              result: result,
-              node: rule,
-              message: e.message,
-            });
-          }
-          classNames.forEach(function(className) {
-            if (classNameErrorCache[className] === undefined) {
-              classNameErrorCache[className] = getClassNameErrors(className, namespace, rule);
-            }
-            if (classNameErrorCache[className]) {
-              stylelint.utils.report({
-                ruleName: ruleName,
-                result: result,
-                node: rule,
-                message: messages.expected(className, classNameErrorCache[className]),
-              });
-            }
-          });
-        });
-      });
-    });
-  };
+		// Valid helper but invalid component prefix
+		// e.g. 'state-zz-button'
+		if (parsedClassName.helper && !parsedClassName.component) {
+			const validPrefixExamples = validComponents
+				.map((prefix) => `"${namespace}${parsedClassName.helper}-${prefix}-"`)
+				.join(', ');
+			return `use the ${getValidSyntax(className, namespace)} syntax. ` +
+				`Valid ${parsedClassName.helper} prefixes: ${validPrefixExamples}`;
+		}
+
+		// Invalid component prefix
+		if (!parsedClassName.component) {
+			const validPrefixExamples = validPrefixes
+				.map((prefix) => `"${namespace}${prefix}-"`)
+				.join(', ');
+			return `start with a valid prefix: ${validPrefixExamples}`;
+		}
+
+		if (!(/^[a-z]/.test(parsedClassName.name))) {
+			return `use the ${getValidSyntax(className, namespace)} syntax`;
+		}
+		if (/___/.test(parsedClassName.name)) {
+			return 'use only two "_" as element separator';
+		}
+		if (/--.*__/.test(parsedClassName.name)) {
+			return `use the ${getValidSyntax(className, namespace)} syntax`;
+		}
+		if (/--(-|.*--)/.test(parsedClassName.name)) {
+			return 'use only one "--" modifier separator';
+		}
+		if (/(^|[^_])_([^_]|$)/.test(parsedClassName.name)) {
+			return 'use "_" only as element separator';
+		}
+		if (parsedClassName.helper && parsedClassName.name.indexOf('--') === -1) {
+			return `use the ${getValidSyntax(className, namespace)} syntax`;
+		}
+	}
+
+	return (root, result) => {
+		const validOptions = stylelint.utils.validateOptions({
+			ruleName,
+			result,
+			actual: options
+		});
+
+		if (!validOptions) {
+			return;
+		}
+
+		const namespace = options.namespace || '';
+		const classNameErrorCache = {};
+		root.walkRules((rule) => {
+			// Skip keyframes
+			if (rule.parent.name === 'keyframes') {
+				return;
+			}
+			rule.selectors.forEach((selector) => {
+				if (selector.indexOf('(') !== -1 && (selector.indexOf(':') === -1 || selector.indexOf('@') !== -1)) {
+					// Skip less mixins
+					return;
+				}
+				resolvedNestedSelector(selector, rule).forEach((resolvedSelector) => {
+					let classNames = [];
+					try {
+						classNames = extractCssClasses(resolvedSelector);
+					} catch (e) {
+						stylelint.utils.report({
+							ruleName,
+							result,
+							node: rule,
+							message: e.message
+						});
+					}
+					classNames.forEach((className) => {
+						if (classNameErrorCache[className] === undefined) {
+							classNameErrorCache[className] = getClassNameErrors(className, namespace, rule);
+						}
+						if (classNameErrorCache[className]) {
+							stylelint.utils.report({
+								ruleName,
+								result,
+								node: rule,
+								message: messages.expected(className, classNameErrorCache[className])
+							});
+						}
+					});
+				});
+			});
+		});
+	};
 });
 
 module.exports.ruleName = ruleName;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@namics/stylelint-bem",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "description": "A stylelint plugin for the Namics BEM definitions",
   "main": "index.js",
   "scripts": {
@@ -30,11 +30,13 @@
     "postcss-resolve-nested-selector": "^0.1.1"
   },
   "peerDependencies": {
-    "stylelint": ">=3.0.2"
+    "stylelint": ">=7.1.0"
   },
   "devDependencies": {
-    "eslint": "^1.10.3",
-    "stylelint": ">=3.0.2",
+    "@namics/eslint-config": "^1.0.0",
+    "eslint": "^3.2.2",
+    "eslint-plugin-import": "^1.13.0",
+    "stylelint": ">=7.1.0",
     "stylelint-test-rule-tape": "^0.2.0"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -1,196 +1,307 @@
-var testRule = require('stylelint-test-rule-tape');
-var plugin = require('..');
+/* eslint max-len:off, prefer-template:off */
+const testRule = require('stylelint-test-rule-tape');
+const plugin = require('..');
 
 testRule(plugin.rule, {
-  ruleName: plugin.ruleName,
-  config: true,
-  skipBasicChecks: true,
+	ruleName: plugin.ruleName,
+	config: true,
+	skipBasicChecks: true,
 
-  accept: [
-    { code: '.a-block {}' },
-    { code: '.m-block {}' },
-    { code: '.o-block {}' },
-    { code: '.l-block {}' },
-    { code: '.g-block {}' },
-    { code: '.h-block {}' },
+	accept: [
+		{
+			code: '.a-block {}'
+		},
+		{
+			code: '.m-block {}'
+		},
+		{
+			code: '.o-block {}'
+		},
+		{
+			code: '.l-block {}'
+		},
+		{
+			code: '.g-block {}'
+		},
+		{
+			code: '.h-block {}'
+		},
 
-    { code: '.state-a-block--state-name {}' },
-    { code: '.state-m-block--state-name {}' },
-    { code: '.state-o-block--state-name {}' },
-    { code: '.state-l-block--state-name {}' },
-    { code: '.state-g-block--state-name {}' },
-    { code: '.state-h-block--state-name {}' },
+		{
+			code: '.state-a-block--state-name {}'
+		},
+		{
+			code: '.state-m-block--state-name {}'
+		},
+		{
+			code: '.state-o-block--state-name {}'
+		},
+		{
+			code: '.state-l-block--state-name {}'
+		},
+		{
+			code: '.state-g-block--state-name {}'
+		},
+		{
+			code: '.state-h-block--state-name {}'
+		},
 
-    { code: '.a-block--modifier {}' },
-    { code: '.m-block--modifier {}' },
-    { code: '.o-block--modifier {}' },
-    { code: '.l-block--modifier {}' },
-    { code: '.g-block--modifier {}' },
-    { code: '.h-block--modifier {}' },
+		{
+			code: '.a-block--modifier {}'
+		},
+		{
+			code: '.m-block--modifier {}'
+		},
+		{
+			code: '.o-block--modifier {}'
+		},
+		{
+			code: '.l-block--modifier {}'
+		},
+		{
+			code: '.g-block--modifier {}'
+		},
+		{
+			code: '.h-block--modifier {}'
+		},
 
-    { code: '.a-block__element {}' },
-    { code: '.m-block__element {}' },
-    { code: '.o-block__element {}' },
-    { code: '.l-block__element {}' },
-    { code: '.g-block__element {}' },
-    { code: '.h-block__element {}' },
-  ],
+		{
+			code: '.a-block__element {}'
+		},
+		{
+			code: '.m-block__element {}'
+		},
+		{
+			code: '.o-block__element {}'
+		},
+		{
+			code: '.l-block__element {}'
+		},
+		{
+			code: '.g-block__element {}'
+		},
+		{
+			code: '.h-block__element {}'
+		}
+	],
 
-  reject: [
-    {
-      code: '.z-block {}',
-      message: 'Expected class name "z-block" to start with a valid prefix: "a-", "m-", "o-", "l-", "g-", "h-", "state-". (' + plugin.ruleName + ')',
-    },
-    {
-      code: '.0-block {}',
-      message: 'Expected class name "0-block" to start with a valid prefix: "a-", "m-", "o-", "l-", "g-", "h-", "state-". (' + plugin.ruleName + ')',
-    },
-    {
-      code: '.-block {}',
-      message: 'Expected class name "-block" to start with a valid prefix: "a-", "m-", "o-", "l-", "g-", "h-", "state-". (' + plugin.ruleName + ')',
-    },
-    {
-      code: '.--block {}',
-      message: 'Expected class name "--block" to start with a valid prefix: "a-", "m-", "o-", "l-", "g-", "h-", "state-". (' + plugin.ruleName + ')',
-    },
-    {
-      code: '.a-block___x {}',
-      message: 'Expected class name "a-block___x" to use only one "__" element separator. (' + plugin.ruleName + ')',
-    },
-    {
-      code: '.a-block__y__x {}',
-      message: 'Expected class name "a-block__y__x" to use only one "__" element separator. (' + plugin.ruleName + ')',
-    },
-    {
-      code: '.a-block---x {}',
-      message: 'Expected class name "a-block---x" to use only one "--" modifier separator. (' + plugin.ruleName + ')',
-    },
-    {
-      code: '.a-block--y--x {}',
-      message: 'Expected class name "a-block--y--x" to use only one "--" modifier separator. (' + plugin.ruleName + ')',
-    },
-    {
-      code: '.a-Block {}',
-      message: 'Expected class name "a-Block" to contain no uppercase letters. (' + plugin.ruleName + ')',
-    },
-    {
-      code: '.m-__element {}',
-      message: 'Expected class name "m-__element" to use [prefix]-[block] syntax. (' + plugin.ruleName + ')',
-    },
-    {
-      code: '.m--modifier {}',
-      message: 'Expected class name "m--modifier" to use [prefix]-[block] syntax. (' + plugin.ruleName + ')',
-    },
-    {
-      code: '.state-m--state {}',
-      message: 'Expected class name "state-m--state" to use state-[prefix]-[block]--[state] syntax. (' + plugin.ruleName + ')',
-    },
-    {
-      code: '.state-block {}',
-      message: 'Expected class name "state-block" to use state-[prefix]-[block]--[state] syntax. Valid state prefixes: "state-a-", "state-m-", "state-o-", "state-l-", "state-g-", "state-h-". (' + plugin.ruleName + ')',
-    },
-    {
-      code: '.state-a-block {}',
-      message: 'Expected class name "state-a-block" to use state-[prefix]-[block]--[state] syntax. (' + plugin.ruleName + ')',
-    },
-    {
-      code: '.state-a-block_b {}',
-      message: 'Expected class name "state-a-block_b" to use "_" only as element separator. (' + plugin.ruleName + ')',
-    },
-  ],
+	reject: [
+		{
+			code: '.z-block {}',
+			message: 'Expected class name "z-block" to start with a valid prefix: "a-", "m-", "o-", "l-", "g-", "h-", "state-". (' + plugin.ruleName + ')'
+		},
+		{
+			code: '.0-block {}',
+			message: 'Expected class name "0-block" to start with a valid prefix: "a-", "m-", "o-", "l-", "g-", "h-", "state-". (' + plugin.ruleName + ')'
+		},
+		{
+			code: '.-block {}',
+			message: 'Expected class name "-block" to start with a valid prefix: "a-", "m-", "o-", "l-", "g-", "h-", "state-". (' + plugin.ruleName + ')'
+		},
+		{
+			code: '.--block {}',
+			message: 'Expected class name "--block" to start with a valid prefix: "a-", "m-", "o-", "l-", "g-", "h-", "state-". (' + plugin.ruleName + ')'
+		},
+		{
+			code: '.a-block___x {}',
+			message: 'Expected class name "a-block___x" to use only two "_" as element separator. (' + plugin.ruleName + ')'
+		},
+		{
+			code: '.a-block---x {}',
+			message: 'Expected class name "a-block---x" to use only one "--" modifier separator. (' + plugin.ruleName + ')'
+		},
+		{
+			code: '.a-block--y--x {}',
+			message: 'Expected class name "a-block--y--x" to use only one "--" modifier separator. (' + plugin.ruleName + ')'
+		},
+		{
+			code: '.a-Block {}',
+			message: 'Expected class name "a-Block" to contain no uppercase letters. (' + plugin.ruleName + ')'
+		},
+		{
+			code: '.m-__element {}',
+			message: 'Expected class name "m-__element" to use the m-[block]__[element] syntax. (' + plugin.ruleName + ')'
+		},
+		{
+			code: '.m--modifier {}',
+			message: 'Expected class name "m--modifier" to use the m-[block]--[modifier] syntax. (' + plugin.ruleName + ')'
+		},
+		{
+			code: '.state-m--state {}',
+			message: 'Expected class name "state-m--state" to use the state-m-[block]--[state] syntax. (' + plugin.ruleName + ')'
+		},
+		{
+			code: '.state-block {}',
+			message: 'Expected class name "state-block" to use the state-[prefix]-[block]--[state] syntax. Valid state prefixes: "state-a-", "state-m-", "state-o-", "state-l-", "state-g-", "state-h-". (' + plugin.ruleName + ')'
+		},
+		{
+			code: '.state-a-block {}',
+			message: 'Expected class name "state-a-block" to use the state-a-[block]--[state] syntax. (' + plugin.ruleName + ')'
+		},
+		{
+			code: '.state-a-block_b {}',
+			message: 'Expected class name "state-a-block_b" to use "_" only as element separator. (' + plugin.ruleName + ')'
+		},
+		{
+			code: '.a--modifier__block {}',
+			message: 'Expected class name "a--modifier__block" to use the a-[block]__[element]--[modifier] syntax. (' + plugin.ruleName + ')'
+		}
+	]
 });
 
 testRule(plugin.rule, {
-  ruleName: plugin.ruleName,
-  config: {
-    namespace: 'namespace-',
-  },
-  skipBasicChecks: true,
+	ruleName: plugin.ruleName,
+	config: {
+		namespace: 'namespace-'
+	},
+	skipBasicChecks: true,
 
-  accept: [
-    { code: '.namespace-a-block {}' },
-    { code: '.namespace-m-block {}' },
-    { code: '.namespace-o-block {}' },
-    { code: '.namespace-l-block {}' },
-    { code: '.namespace-g-block {}' },
-    { code: '.namespace-h-block {}' },
+	accept: [
+		{
+			code: '.namespace-a-block {}'
+		},
+		{
+			code: '.namespace-m-block {}'
+		},
+		{
+			code: '.namespace-o-block {}'
+		},
+		{
+			code: '.namespace-l-block {}'
+		},
+		{
+			code: '.namespace-g-block {}'
+		},
+		{
+			code: '.namespace-h-block {}'
+		},
 
-    { code: '.namespace-state-a-block--state-name {}' },
-    { code: '.namespace-state-m-block--state-name {}' },
-    { code: '.namespace-state-o-block--state-name {}' },
-    { code: '.namespace-state-l-block--state-name {}' },
-    { code: '.namespace-state-g-block--state-name {}' },
-    { code: '.namespace-state-h-block--state-name {}' },
+		{
+			code: '.namespace-state-a-block--state-name {}'
+		},
+		{
+			code: '.namespace-state-m-block--state-name {}'
+		},
+		{
+			code: '.namespace-state-o-block--state-name {}'
+		},
+		{
+			code: '.namespace-state-l-block--state-name {}'
+		},
+		{
+			code: '.namespace-state-g-block--state-name {}'
+		},
+		{
+			code: '.namespace-state-h-block--state-name {}'
+		},
 
-    { code: '.namespace-a-block--modifier {}' },
-    { code: '.namespace-m-block--modifier {}' },
-    { code: '.namespace-o-block--modifier {}' },
-    { code: '.namespace-l-block--modifier {}' },
-    { code: '.namespace-g-block--modifier {}' },
-    { code: '.namespace-h-block--modifier {}' },
+		{
+			code: '.namespace-a-block--modifier {}'
+		},
+		{
+			code: '.namespace-m-block--modifier {}'
+		},
+		{
+			code: '.namespace-o-block--modifier {}'
+		},
+		{
+			code: '.namespace-l-block--modifier {}'
+		},
+		{
+			code: '.namespace-g-block--modifier {}'
+		},
+		{
+			code: '.namespace-h-block--modifier {}'
+		},
 
-    { code: '.namespace-a-block__block {}' },
-    { code: '.namespace-m-block__block {}' },
-    { code: '.namespace-o-block__block {}' },
-    { code: '.namespace-l-block__block {}' },
-    { code: '.namespace-g-block__block {}' },
-    { code: '.namespace-h-block__block {}' },
-  ],
+		{
+			code: '.namespace-a-block__block {}'
+		},
+		{
+			code: '.namespace-m-block__block {}'
+		},
+		{
+			code: '.namespace-o-block__block {}'
+		},
+		{
+			code: '.namespace-l-block__block {}'
+		},
+		{
+			code: '.namespace-g-block__block {}'
+		},
+		{
+			code: '.namespace-h-block__block {}'
+		}
+	],
 
-  reject: [
-    {
-      code: '.a-block {}',
-      message: 'Expected class name "a-block" to use the namespace "namespace-". (' + plugin.ruleName + ')',
-    },
-    {
-      code: '.namespace-z-block {}',
-      message: 'Expected class name "namespace-z-block" to start with a valid prefix: "namespace-a-", "namespace-m-", "namespace-o-", "namespace-l-", "namespace-g-", "namespace-h-", "namespace-state-". (' + plugin.ruleName + ')',
-    },
-    {
-      code: '.namespace-z-block__element {}',
-      message: 'Expected class name "namespace-z-block__element" to start with a valid prefix: "namespace-a-", "namespace-m-", "namespace-o-", "namespace-l-", "namespace-g-", "namespace-h-", "namespace-state-". (' + plugin.ruleName + ')',
-    },
-    {
-      code: '.namespace-m-__element {}',
-      message: 'Expected class name "namespace-m-__element" to use namespace-[prefix]-[block] syntax. (' + plugin.ruleName + ')',
-    },
-    {
-      code: '.namespace-m--modifier {}',
-      message: 'Expected class name "namespace-m--modifier" to use namespace-[prefix]-[block] syntax. (' + plugin.ruleName + ')',
-    },
-    {
-      code: '.namespace-state-m--state {}',
-      message: 'Expected class name "namespace-state-m--state" to use namespace-state-[prefix]-[block]--[state] syntax. (' + plugin.ruleName + ')',
-    },
-    {
-      code: '.namespace-state-m__element {}',
-      message: 'Expected class name "namespace-state-m__element" to use namespace-state-[prefix]-[block]--[state] syntax. Valid namespace-state prefixes: "namespace-state-a-", "namespace-state-m-", "namespace-state-o-", "namespace-state-l-", "namespace-state-g-", "namespace-state-h-". (' + plugin.ruleName + ')',
-    },
-    {
-      code: '.namespace-state-block {}',
-      message: 'Expected class name "namespace-state-block" to use namespace-state-[prefix]-[block]--[state] syntax. Valid namespace-state prefixes: "namespace-state-a-", "namespace-state-m-", "namespace-state-o-", "namespace-state-l-", "namespace-state-g-", "namespace-state-h-". (' + plugin.ruleName + ')',
-    },
-    {
-      code: '.namespace-state-a-block {}',
-      message: 'Expected class name "namespace-state-a-block" to use namespace-state-[prefix]-[block]--[state] syntax. (' + plugin.ruleName + ')',
-    },
-  ],
+	reject: [
+		{
+			code: '.a-block {}',
+			message: 'Expected class name "a-block" to use the namespace "namespace-". (' + plugin.ruleName + ')'
+		},
+		{
+			code: '.namespace-z-block {}',
+			message: 'Expected class name "namespace-z-block" to start with a valid prefix: "namespace-a-", "namespace-m-", "namespace-o-", "namespace-l-", "namespace-g-", "namespace-h-", "namespace-state-". (' + plugin.ruleName + ')'
+		},
+		{
+			code: '.namespace-z-block__element {}',
+			message: 'Expected class name "namespace-z-block__element" to start with a valid prefix: "namespace-a-", "namespace-m-", "namespace-o-", "namespace-l-", "namespace-g-", "namespace-h-", "namespace-state-". (' + plugin.ruleName + ')'
+		},
+		{
+			code: '.namespace-m-__element {}',
+			message: 'Expected class name "namespace-m-__element" to use the namespace-m-[block]__[element] syntax. (' + plugin.ruleName + ')'
+		},
+		{
+			code: '.namespace-m--modifier {}',
+			message: 'Expected class name "namespace-m--modifier" to use the namespace-m-[block]--[modifier] syntax. (' + plugin.ruleName + ')'
+		},
+		{
+			code: '.namespace-state-m--state {}',
+			message: 'Expected class name "namespace-state-m--state" to use the namespace-state-m-[block]--[state] syntax. (' + plugin.ruleName + ')'
+		},
+		{
+			code: '.namespace-state-m__element {}',
+			message: 'Expected class name "namespace-state-m__element" to use the namespace-state-[prefix]-[block]__[element]--[state] syntax. Valid state prefixes: "namespace-state-a-", "namespace-state-m-", "namespace-state-o-", "namespace-state-l-", "namespace-state-g-", "namespace-state-h-". (' + plugin.ruleName + ')'
+		},
+		{
+			code: '.namespace-state-block {}',
+			message: 'Expected class name "namespace-state-block" to use the namespace-state-[prefix]-[block]--[state] syntax. Valid state prefixes: "namespace-state-a-", "namespace-state-m-", "namespace-state-o-", "namespace-state-l-", "namespace-state-g-", "namespace-state-h-". (' + plugin.ruleName + ')'
+		},
+		{
+			code: '.namespace-state-a-block {}',
+			message: 'Expected class name "namespace-state-a-block" to use the namespace-state-a-[block]--[state] syntax. (' + plugin.ruleName + ')'
+		},
+		{
+			code: '.namespace-a--modifier__block {}',
+			message: 'Expected class name "namespace-a--modifier__block" to use the namespace-a-[block]__[element]--[modifier] syntax. (' + plugin.ruleName + ')'
+		}
+	]
 });
 
 // Should not conflict with keyframes or less mixins
 testRule(plugin.rule, {
-  ruleName: plugin.ruleName,
-  config: {},
-  skipBasicChecks: true,
+	ruleName: plugin.ruleName,
+	config: {},
+	skipBasicChecks: true,
 
-  accept: [
-    { code: '@keyframes blue-background-change { 0% { background: black } }' },
-    { code: '.mixin() { }' },
-    { code: '.mixin(@prop: black) { background: @prop }' },
-    { code: '#namespace { }' },
-  ],
+	accept: [
+		{
+			code: '@keyframes blue-background-change { 0% { background: black } }'
+		},
+		{
+			code: '.mixin() { }'
+		},
+		{
+			code: '.mixin(@prop: black) { background: @prop }'
+		},
+		{
+			code: '#namespace { }'
+		}
+	],
 
-  reject: [
-    { code: '.no-mixin:not(x) { }'},
-  ],
+	reject: [
+		{
+			code: '.no-mixin:not(x) { }'
+		}
+	]
 });


### PR DESCRIPTION
drop node 0.12 support
use namics code style
forbid placing modifiers in front of elements
allow to use multiple elements e.g. `[prefix]-[block]__[element]__[element]`